### PR TITLE
Drop uneless codecov token

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -32,6 +32,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/coverage-final.json
           fail_ci_if_error: true


### PR DESCRIPTION
They are only required for private repos

Ref https://github.com/codecov/codecov-action#usage