### PR TITLE
Fix removing recurrence rules not creating exceptions

### DIFF
--- a/src/components/root/abstractRecurringComponent.js
+++ b/src/components/root/abstractRecurringComponent.js
@@ -420,7 +420,8 @@ export default class AbstractRecurringComponent extends AbstractComponent {
 	 * @returns {boolean}
 	 */
 	canCreateRecurrenceExceptions() {
-		return this.isRecurring() || this.modifiesFuture()
+		const primaryIsRecurring = this.primaryItem?.isRecurring() ?? false
+		return this.isRecurring() || this.modifiesFuture() || (!this.isRecurring() && primaryIsRecurring)
 	}
 
 	/**


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/3282

Removing recurrence rules did not trigger the creation of recurrence exceptions because `this.isRecurring()` is always false if the edited/forked event component has no recurrence rules anymore. I added an extra condition to catch the case when a fork has no recurrence set but still needs to create an exception.

### TODO
* [x] Fix tests