### PR TITLE
Update workflows to npm v7 and node >= v14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,16 +12,19 @@ jobs:
 
     strategy:
       matrix:
-        node-versions: [12.x]
+        node-version: [14, 15, 16]
 
-    name: node${{ matrix.node-versions }}
+    name: node${{ matrix.node-version }}
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up node ${{ matrix.node-versions }}
-        uses: actions/setup-node@v1
+      - name: Set up node ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          node-versions: ${{ matrix.node-versions }}
+          node-version: ${{ matrix.node-version }}
+
+      - name: Set up npm 7
+        run: npm i -g npm@7
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -12,16 +12,19 @@ jobs:
 
     strategy:
       matrix:
-        node-versions: [12.x]
+        node-version: [14, 15, 16]
 
-    name: node${{ matrix.node-versions }}
+    name: node${{ matrix.node-version }}
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up node ${{ matrix.node-versions }}
-        uses: actions/setup-node@v1
+      - name: Set up node ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          node-versions: ${{ matrix.node-versions }}
+          node-version: ${{ matrix.node-version }}
+
+      - name: Set up npm 7
+        run: npm i -g npm@7
 
       - name: Install dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "url": "https://github.com/nextcloud/calendar-js/issues"
   },
   "homepage": "https://github.com/nextcloud/calendar-js#readme",
+  "engines": {
+    "node": ">=14.0.0",
+    "npm": ">=7.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.14.6",
     "@babel/preset-env": "^7.14.8",


### PR DESCRIPTION
Our package lock is on version 2 already but we forgot to adjust the engines field in package.json and our workflows.