### PR TITLE
Replace modern js with classic js

### DIFF
--- a/src/components/root/abstractRecurringComponent.js
+++ b/src/components/root/abstractRecurringComponent.js
@@ -420,7 +420,10 @@ export default class AbstractRecurringComponent extends AbstractComponent {
 	 * @returns {boolean}
 	 */
 	canCreateRecurrenceExceptions() {
-		const primaryIsRecurring = this.primaryItem?.isRecurring() ?? false
+		let primaryIsRecurring = false
+		if (this.primaryItem && this.primaryItem.isRecurring()) {
+			primaryIsRecurring = true
+		}
 		return this.isRecurring() || this.modifiesFuture() || (!this.isRecurring() && primaryIsRecurring)
 	}
 


### PR DESCRIPTION
Just before we have https://github.com/nextcloud/calendar-js/pull/274, because right now linking nc/vue to Mail gives my compilation errors as two different version of the lib are there and one contains js that the tools can't process.