### PR TITLE
Don't minify code and refactor rollup config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
       "name": "@nextcloud/calendar-js",
       "version": "2.0.0",
       "license": "AGPL-3.0-or-later",
-      "dependencies": {
-        "ical.js": "^1.4.0",
-        "uuid": "^8.3.2"
-      },
       "devDependencies": {
         "@babel/core": "^7.14.6",
         "@nextcloud/babel-config": "^1.0.0",
@@ -27,11 +23,15 @@
         "esdoc-standard-plugin": "^1.0.0",
         "jest": "^27.0.6",
         "rollup": "^2.53.2",
-        "rollup-plugin-terser": "^7.0.2"
+        "rollup-plugin-peer-deps-external": "^2.2.4"
       },
       "engines": {
         "node": ">=14.0.0",
         "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "ical.js": "^1.4.0",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3860,7 +3860,8 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/comment-parser": {
       "version": "1.2.4",
@@ -5999,7 +6000,8 @@
     "node_modules/ical.js": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.4.0.tgz",
-      "integrity": "sha512-ltHZuOFNNjcyEYbzDgjemS7LWIFh2vydJeznxQHUh3dnarbxqOYsWONYteBVAq1MEOHnwXFGN2eskZReHclnrA=="
+      "integrity": "sha512-ltHZuOFNNjcyEYbzDgjemS7LWIFh2vydJeznxQHUh3dnarbxqOYsWONYteBVAq1MEOHnwXFGN2eskZReHclnrA==",
+      "peer": true
     },
     "node_modules/ice-cap": {
       "version": "0.0.4",
@@ -9617,6 +9619,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -10036,54 +10039,13 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-terser": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
-      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+    "node_modules/rollup-plugin-peer-deps-external": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
+      "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
       "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
-      },
       "peerDependencies": {
-        "rollup": "^2.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/jest-worker": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "rollup": "*"
       }
     },
     "node_modules/safe-buffer": {
@@ -10143,15 +10105,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shebang-command": {
@@ -10646,6 +10599,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
       "integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "commander": "^2.20.0",
         "source-map": "~0.7.2",
@@ -10724,6 +10678,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -11004,6 +10959,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -14429,7 +14385,8 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "comment-parser": {
       "version": "1.2.4",
@@ -16105,7 +16062,8 @@
     "ical.js": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.4.0.tgz",
-      "integrity": "sha512-ltHZuOFNNjcyEYbzDgjemS7LWIFh2vydJeznxQHUh3dnarbxqOYsWONYteBVAq1MEOHnwXFGN2eskZReHclnrA=="
+      "integrity": "sha512-ltHZuOFNNjcyEYbzDgjemS7LWIFh2vydJeznxQHUh3dnarbxqOYsWONYteBVAq1MEOHnwXFGN2eskZReHclnrA==",
+      "peer": true
     },
     "ice-cap": {
       "version": "0.0.4",
@@ -18904,6 +18862,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -19231,45 +19190,12 @@
         "fsevents": "~2.3.2"
       }
     },
-    "rollup-plugin-terser": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
-      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+    "rollup-plugin-peer-deps-external": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
+      "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
       "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "jest-worker": "^26.2.1",
-        "serialize-javascript": "^4.0.0",
-        "terser": "^5.0.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-worker": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-          "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^7.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
+      "requires": {}
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -19316,15 +19242,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
-    },
-    "serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -19714,6 +19631,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
       "integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.7.2",
@@ -19724,7 +19642,8 @@
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -19992,7 +19911,8 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "peer": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -5,15 +5,14 @@
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
   "files": [
-      "README.md",
-      "LICENSE",
-      "dist",
-      "resources/timezones/zones.json"
+    "README.md",
+    "LICENSE",
+    "dist",
+    "resources/timezones/zones.json"
   ],
   "scripts": {
-    "dev": "rollup --config rollup.config.js",
     "watch": "rollup --config rollup.config.js --watch",
-    "build": "NODE_ENV=production rollup --config rollup.config.js",
+    "build": "rollup --config rollup.config.js",
     "build-doc": "./node_modules/.bin/esdoc",
     "lint": "eslint --ext .js src",
     "lint:fix": "eslint --ext .js src --fix",
@@ -54,9 +53,9 @@
     "esdoc-standard-plugin": "^1.0.0",
     "jest": "^27.0.6",
     "rollup": "^2.53.2",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-plugin-peer-deps-external": "^2.2.4"
   },
-  "dependencies": {
+  "peerDependencies": {
     "ical.js": "^1.4.0",
     "uuid": "^8.3.2"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,42 +3,31 @@ const { nodeResolve } = require('@rollup/plugin-node-resolve')
 const json = require('@rollup/plugin-json')
 const commonjs = require('@rollup/plugin-commonjs')
 const { babel } = require('@rollup/plugin-babel')
-const { terser } = require('rollup-plugin-terser')
+const peerDepsExternal = require('rollup-plugin-peer-deps-external')
 
-/**
- * Create a configuration for a rollup bundle using a custom output definition.
- *
- * @param {object} output Rollup config output definition.
- * @return {object} Full rollup config for a bundle.
- */
-function createConfig(output) {
-	return {
-		input: 'src/index.js',
-		output: {
+module.exports = {
+	input: 'src/index.js',
+	output: [
+		{
 			name: pkg.name,
+			file: pkg.main,
+			format: 'umd',
 			sourcemap: true,
-			...output,
 		},
-		plugins: [
-			nodeResolve(),
-			json(),
-			commonjs(),
-			babel({
-				babelHelpers: 'bundled',
-			}),
-			(process.env.NODE_ENV === 'production' && terser()),
-		],
-		external: Object.keys(pkg.dependencies),
-	}
+		{
+			name: pkg.name,
+			file: pkg.module,
+			format: 'esm',
+			sourcemap: true,
+		},
+	],
+	plugins: [
+		peerDepsExternal(),
+		nodeResolve(),
+		json(),
+		commonjs(),
+		babel({
+			babelHelpers: 'bundled',
+		}),
+	],
 }
-
-module.exports = [
-	createConfig({
-		file: pkg.main,
-		format: 'umd',
-	}),
-	createConfig({
-		file: pkg.module,
-		format: 'esm',
-	}),
-]


### PR DESCRIPTION
I got inspired by https://blog.harveydelaney.com/creating-your-own-vue-component-library/ and improved the rollup config.

I finally managed to fix source maps :tada: Additionally, we don't need to minify the code because it will be minified by the bundling application anyways.

A minor version bump is sufficient for this PR.