### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/parsers/icalendarParser.js
+++ b/src/parsers/icalendarParser.js
@@ -320,7 +320,7 @@ export default class ICalendarParser extends AbstractParser {
 				continue
 			}
 
-			const tzid = tzidMatcher[0].substr(5)
+			const tzid = tzidMatcher[0].slice(5)
 			const timezone = new Timezone(tzid, match)
 			this._timezones.set(tzid, timezone)
 		}

--- a/src/parsers/repairsteps/icalendar/icalendarMultipleVCalendarBlocksRepairStep.js
+++ b/src/parsers/repairsteps/icalendar/icalendarMultipleVCalendarBlocksRepairStep.js
@@ -74,7 +74,7 @@ export default class ICalendarMultipleVCalendarBlocksRepairStep extends Abstract
 					return ''
 				}
 
-				const tzid = uc(tzidMatcher[0].substr(5))
+				const tzid = uc(tzidMatcher[0].slice(5))
 				if (includedTimezones.has(tzid)) {
 					// If we already included this timezone, just skip
 					return ''


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.