### PR TITLE
Test recent node lts versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 15, 16]
+        node-version: [14, 16, 18]
 
     name: node${{ matrix.node-version }}
     steps:

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 15, 16]
+        node-version: [14, 16, 18]
 
     name: node${{ matrix.node-version }}
     steps:


### PR DESCRIPTION
We should run workflows on all recent Node LTS versions. Stable and LTS distros usually ship one of those versions. Rolling distros and people not using nvm proceed on their own risk anyway.

Ref https://nodejs.org/en/about/releases/