### PR TITLE
chore(deps)!: Drop support for Node 14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
 
     name: node${{ matrix.node-version }}
     steps:
@@ -22,9 +22,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Set up npm 7
-        run: npm i -g npm@7
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
 
     name: node${{ matrix.node-version }}
     steps:
@@ -22,9 +22,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Set up npm 7
-        run: npm i -g npm@7
 
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,8 @@
         "rollup-plugin-peer-deps-external": "^2.2.4"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "peerDependencies": {
         "ical.js": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "homepage": "https://github.com/nextcloud/calendar-js#readme",
   "engines": {
-    "node": ">=14.0.0",
-    "npm": ">=7.0.0"
+    "node": ">=16.0.0",
+    "npm": ">=8.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",


### PR DESCRIPTION
BREAKING CHANGE: package requires Node 16+ now
