### PR TITLE
fix: adjust RRULE count when forking occurrences

### DIFF
--- a/src/components/root/abstractRecurringComponent.js
+++ b/src/components/root/abstractRecurringComponent.js
@@ -357,6 +357,21 @@ export default class AbstractRecurringComponent extends AbstractComponent {
 			throw new TypeError('Can\'t fork item without a DTSTART')
 		}
 
+		// Adjust RRULE COUNT if present
+		const rrule = occurrence.getFirstPropertyFirstValue('RRULE')
+		if (rrule?.count) {
+			let index = occurrence.recurrenceManager.countAllOccurrencesBetween(
+				occurrence.getReferenceRecurrenceId(),
+				recurrenceId,
+			)
+
+			index -= 1 // Don't count the forked occurrence
+			rrule.count -= index
+			if (rrule.count < 1) {
+				rrule.count = 1
+			}
+		}
+
 		if (occurrence.getFirstPropertyFirstValue('DTSTART').timezoneId !== recurrenceId.timezoneId) {
 			const originalTimezone = occurrence.getFirstPropertyFirstValue('DTSTART').getICALTimezone()
 			recurrenceId = recurrenceId.getInICALTimezone(originalTimezone)

--- a/src/recurrence/recurrenceManager.js
+++ b/src/recurrence/recurrenceManager.js
@@ -635,6 +635,45 @@ export default class RecurrenceManager {
 	}
 
 	/**
+	 * Counts all occurrences in the given time-range.
+	 * This function works solely on the basis of recurrence-ids.
+	 * Start and end are inclusive.
+	 *
+	 * @param {DateTimeValue} queriedTimeRangeStart Start of time-range
+	 * @param {DateTimeValue} queriedTimeRangeEnd End of time-range
+	 * @return {number} Count of occurrences in the given time-range
+	 */
+	countAllOccurrencesBetween(queriedTimeRangeStart, queriedTimeRangeEnd) {
+		if (!this.masterItem.isRecurring()) {
+			if (typeof this.masterItem.isInTimeFrame === 'function'
+				&& !this.masterItem.isInTimeFrame(queriedTimeRangeStart, queriedTimeRangeEnd)) {
+				return 0
+			}
+
+			return 1
+		}
+
+		const iterator = this._getRecurExpansionObject()
+		const queriedICALJsTimeRangeStart = queriedTimeRangeStart.toICALJs()
+		const queriedICALJsTimeRangeEnd = queriedTimeRangeEnd.toICALJs()
+
+		let count = 0
+		let next
+		while ((next = iterator.next())) {
+			if (next.compare(queriedICALJsTimeRangeStart) === -1) {
+				continue
+			}
+
+			if (next.compare(queriedICALJsTimeRangeEnd) === 1) {
+				break
+			}
+
+			count += 1
+		}
+		return count
+	}
+
+	/**
 	 * Get all occurrences between start and end
 	 * Start and End are inclusive
 	 *


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/3283

Ref my comment from that issue:
> I think the problem is that forked recurrence items always inherit the the full recurrence count from the master. Instead, it should be decremented for every instance.

## After

https://user-images.githubusercontent.com/1479486/222720668-c1bf892e-9596-4a1f-bd81-e016f877d09d.mp4

