### PR TITLE
Bump uuid from 8.3.2 to 9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       },
       "peerDependencies": {
         "ical.js": "^1.5.0",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -9669,9 +9669,9 @@
       "peer": true
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -17141,9 +17141,9 @@
       "peer": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "peer": true
     },
     "v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "peerDependencies": {
     "ical.js": "^1.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
This bumps the `uuid` peer dependency from 8.3.2 to 9.0.0.

I guess this will be a breaking change, requiring a major version bump later on, as it forces the dev to update the dependency to `uuid` in his app.