### PR TITLE
attendeeProperty: Add member function

### DIFF
--- a/src/properties/attendeeProperty.js
+++ b/src/properties/attendeeProperty.js
@@ -2,6 +2,7 @@
  * @copyright Copyright (c) 2019 Georg Ehrke
  *
  * @author Georg Ehrke <georg-nextcloud@ehrke.email>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license AGPL-3.0-or-later
  *
@@ -205,6 +206,25 @@ export default class AttendeeProperty extends Property {
 	 */
 	set email(email) {
 		this.value = startStringWith(email, 'mailto:')
+	}
+
+	/**
+	 * Gets the email addresses of groups the attendee is a part of
+	 *
+	 * @return {string[]|null} The email addresses of the groups
+	 */
+	get member() {
+		return this.getParameter('MEMBER')?.value ?? null
+	}
+
+	/**
+	 * Sets the email addresses of groups the attendee is a part of
+	 *
+	 * @param {string[]} members The email addresses of the groups
+	 */
+	set member(members) {
+		members = members.map(member => startStringWith(member, 'mailto:'))
+		this.updateParameterIfExist('MEMBER', members)
 	}
 
 	/**

--- a/tests/unit/properties/attendeeProperty.test.js
+++ b/tests/unit/properties/attendeeProperty.test.js
@@ -2,6 +2,7 @@
  * @copyright Copyright (c) 2019 Georg Ehrke
  *
  * @author Georg Ehrke <georg-nextcloud@ehrke.email>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license AGPL-3.0-or-later
  *
@@ -263,6 +264,36 @@ it('AttendeeProperty should provide easy getter/setter for email', () => {
 
 	property.email = 'bar@example.com'
 	expect(property.email).toEqual('mailto:bar@example.com')
+})
+
+it('AttendeeProperty should provide easy getter/setter for member', () => {
+	const icalValue = ICAL.Property.fromString('ATTENDEE;MEMBER="mailto:projectA@example.com","mailto:projectB@example.com";CN=janedoe:mailto:janedoe@example.com')
+	const property = AttendeeProperty.fromICALJs(icalValue)
+
+	expect(property.member).toEqual(['mailto:projectA@example.com', 'mailto:projectB@example.com'])
+
+	property.member = ['foo@bar.com']
+	expect(property.member).toEqual(['mailto:foo@bar.com'])
+
+	property.lock()
+	expect(property.isLocked()).toEqual(true)
+
+	expect(() => {
+		property.member = ['mailto:projc@example.com']
+	}).toThrow(ModificationNotAllowedError)
+	expect(property.member).toEqual(['mailto:foo@bar.com'])
+
+	property.unlock()
+
+	property.member = ['bar@example.com', 'mailto:foo@example.com']
+	expect(property.member).toEqual(['mailto:bar@example.com', 'mailto:foo@example.com'])
+})
+
+it('AttendeeProperty should handle missing member gracefully', () => {
+	const icalValue = ICAL.Property.fromString('ATTENDEE;CN=Foo;PARTSTAT=DECLINED123;LANGUAGE=EN:mailto:mrbig@example.com')
+	const property = AttendeeProperty.fromICALJs(icalValue)
+
+	expect(property.member).toEqual(null)
 })
 
 it('AttendeeProperty should provide easy getter/setter for commonName', () => {


### PR DESCRIPTION
Adding the possibility to read and set the MEMBER attribute as described in https://www.rfc-editor.org/rfc/rfc5545#section-3.2.11

<strike>Not sure yet how to deal with:

- Testing and adding tests
- Read and write multiple addresses of MEMBER field
- Sanity check if MEMBER field exists</strike>

Would like to use this field in https://github.com/nextcloud/calendar-js/pull/627