### PR TITLE
feat: use browser-native UUID function

### DIFF
--- a/__mocks__/uuid.js
+++ b/__mocks__/uuid.js
@@ -1,3 +1,0 @@
-module.exports = {
-	v4: jest.fn(() => 'RANDOM UUID 123'),
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,7 @@
       },
       "peerDependencies": {
         "@nextcloud/timezones": "^0.1.1",
-        "ical.js": "^2.1.0",
-        "uuid": "^11.0.5"
+        "ical.js": "^2.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -12431,20 +12430,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -22235,12 +22220,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "uuid": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
-      "peer": true
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
   },
   "peerDependencies": {
     "@nextcloud/timezones": "^0.1.1",
-    "ical.js": "^2.1.0",
-    "uuid": "^11.0.5"
+    "ical.js": "^2.1.0"
   },
   "babel": {
     "presets": [

--- a/src/components/root/abstractRecurringComponent.js
+++ b/src/components/root/abstractRecurringComponent.js
@@ -31,7 +31,7 @@ import PeriodValue from '../../values/periodValue.js'
 import { dateFactory } from '../../factories/dateFactory.js'
 import { uc } from '../../helpers/stringHelper.js'
 import RecurrenceManager from '../../recurrence/recurrenceManager.js'
-import { v4 as uuid } from 'uuid'
+import { randomUUID } from '../../helpers/cryptoHelper.js'
 import RelationProperty from '../../properties/relationProperty.js'
 import AttendeeProperty from '../../properties/attendeeProperty.js'
 import { Timezone } from '@nextcloud/timezones'
@@ -491,7 +491,7 @@ export default class AbstractRecurringComponent extends AbstractComponent {
 			this._originalRecurrenceId = null
 
 			this.primaryItem = this
-			this.updatePropertyWithValue('UID', uuid())
+			this.updatePropertyWithValue('UID', randomUUID())
 			this._cachedId = null
 
 			this.addRelation('SIBLING', previousPrimaryItem.uid)

--- a/src/helpers/__mocks__/cryptoHelper.js
+++ b/src/helpers/__mocks__/cryptoHelper.js
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export function randomUUID() {
+	return 'RANDOM UUID 123'
+}

--- a/src/helpers/cryptoHelper.js
+++ b/src/helpers/cryptoHelper.js
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Generates a random UUID v4.
+ *
+ * @return {string}
+ */
+export function randomUUID() {
+	if (crypto?.randomUUID) {
+		// Only available in secure contexts
+		return crypto.randomUUID()
+	}
+
+	return insecureUuidV4()
+}
+
+/**
+ * Generates a random UUID v4 from a weak, non-cryptographic random number generator.
+ * Please use randomUUID() instead.
+ *
+ * Adapted from https://gist.github.com/scwood/3bff42cc005cc20ab7ec98f0d8e1d59d
+ * Copyright 2018 Spencer Wood
+ *
+ * @return {string}
+ */
+export function insecureUuidV4() {
+	const uuid = new Array(36)
+	for (let i = 0; i < 36; i++) {
+		uuid[i] = Math.floor(Math.random() * 16)
+	}
+	uuid[14] = 4 // set bits 12-15 of time-high-and-version to 0100
+	uuid[19] = uuid[19] &= ~(1 << 2) // set bit 6 of clock-seq-and-reserved to zero
+	uuid[19] = uuid[19] |= (1 << 3) // set bit 7 of clock-seq-and-reserved to one
+	uuid[8] = uuid[13] = uuid[18] = uuid[23] = '-'
+	return uuid.map((x) => x.toString(16)).join('')
+}

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@
  *
  */
 import { getParserManager } from './parsers/parserManager.js'
-import { v4 as uuid } from 'uuid'
+import { randomUUID } from './helpers/cryptoHelper.js'
 import DateTimeValue from './values/dateTimeValue.js'
 import { dateFactory } from './factories/dateFactory.js'
 import CalendarComponent from './components/calendarComponent.js'
@@ -73,7 +73,7 @@ export function createEvent(start, end) {
 	eventComponent.updatePropertyWithValue('DTSTAMP', DateTimeValue.fromJSDate(dateFactory(), true))
 	eventComponent.updatePropertyWithValue('LAST-MODIFIED', DateTimeValue.fromJSDate(dateFactory(), true))
 	eventComponent.updatePropertyWithValue('SEQUENCE', 0)
-	eventComponent.updatePropertyWithValue('UID', uuid())
+	eventComponent.updatePropertyWithValue('UID', randomUUID())
 	eventComponent.updatePropertyWithValue('DTSTART', start)
 	eventComponent.updatePropertyWithValue('DTEND', end)
 
@@ -97,7 +97,7 @@ export function createFreeBusyRequest(start, end, organizer, attendees) {
 	const freeBusyComponent = new FreeBusyComponent('VFREEBUSY')
 
 	freeBusyComponent.updatePropertyWithValue('DTSTAMP', DateTimeValue.fromJSDate(dateFactory(), true))
-	freeBusyComponent.updatePropertyWithValue('UID', uuid())
+	freeBusyComponent.updatePropertyWithValue('UID', randomUUID())
 	freeBusyComponent.updatePropertyWithValue('DTSTART', start.clone().getInUTC())
 	freeBusyComponent.updatePropertyWithValue('DTEND', end.clone().getInUTC())
 	freeBusyComponent.addProperty(organizer.clone())

--- a/src/parsers/repairsteps/icalendar/icalendarAddMissingUIDRepairStep.js
+++ b/src/parsers/repairsteps/icalendar/icalendarAddMissingUIDRepairStep.js
@@ -20,7 +20,7 @@
  *
  */
 import AbstractRepairStep from '../abstractRepairStep.js'
-import { v4 as uuid } from 'uuid'
+import { randomUUID } from '../../../helpers/cryptoHelper.js'
 
 /**
  * @class ICalendarAddMissingUIDRepairStep
@@ -36,7 +36,7 @@ export default class ICalendarAddMissingUIDRepairStep extends AbstractRepairStep
 		return ics
 			.replace(/^BEGIN:(VEVENT|VTODO|VJOURNAL)$(((?!^END:(VEVENT|VTODO|VJOURNAL)$)(?!^UID.*$)(.|\n))*)^END:(VEVENT|VTODO|VJOURNAL)$\n/gm, (match, vobjectName, vObjectBlock) => {
 				return 'BEGIN:' + vobjectName + '\r\n'
-					+ 'UID:' + uuid()
+					+ 'UID:' + randomUUID()
 					+ vObjectBlock
 					+ 'END:' + vobjectName + '\r\n'
 			})

--- a/tests/integration/creating/createEvent.test.js
+++ b/tests/integration/creating/createEvent.test.js
@@ -25,6 +25,7 @@ import { createEvent } from '../../../src';
 import { Timezone } from '@nextcloud/timezones';
 
 jest.mock('../../../src/factories/dateFactory.js')
+jest.mock('../../../src/helpers/cryptoHelper.js')
 
 it('should create events based on parameters - allday', () => {
 	const start = DateTimeValue.fromData({

--- a/tests/integration/creating/createFreeBusyRequest.test.js
+++ b/tests/integration/creating/createFreeBusyRequest.test.js
@@ -23,7 +23,9 @@
 import { createFreeBusyRequest } from '../../../src';
 import DateTimeValue from '../../../src/values/dateTimeValue.js';
 import AttendeeProperty from '../../../src/properties/attendeeProperty.js';
+
 jest.mock('../../../src/factories/dateFactory.js')
+jest.mock('../../../src/helpers/cryptoHelper.js')
 
 it('should create a freeBusy request', () => {
 	const start = DateTimeValue.fromData({

--- a/tests/integration/parser/parser.test.js
+++ b/tests/integration/parser/parser.test.js
@@ -26,6 +26,7 @@ import DateTimeValue from '../../../src/values/dateTimeValue.js'
 import DurationValue from '../../../src/values/durationValue.js';
 
 jest.mock('../../../src/factories/dateFactory.js')
+jest.mock('../../../src/helpers/cryptoHelper.js')
 
 it('ParserManager should provide a list of supported file-types', () => {
 	const parserManager = getParserManager()

--- a/tests/unit/helpers/cryptoHelper.test.js
+++ b/tests/unit/helpers/cryptoHelper.test.js
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { insecureUuidV4, randomUUID } from '../../../src/helpers/cryptoHelper.js'
+
+it('randomUUID should return a random UUIDv4', () => {
+	expect(typeof randomUUID() === 'string').toEqual(true)
+	for (let i = 0; i < 100; i++) {
+		expect(randomUUID())
+			.toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+	}
+})
+
+it('randomUUID should use the built-in implementation in secure contexts', () => {
+	crypto.randomUUID = () => 'RANDOM UUID 123'
+	expect(randomUUID()).toBe('RANDOM UUID 123')
+})
+
+it('insecureUuidV4 should return a random UUIDv4', () => {
+	expect(typeof insecureUuidV4() === 'string').toEqual(true)
+	for (let i = 0; i < 100; i++) {
+		expect(insecureUuidV4())
+			.toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+	}
+})

--- a/tests/unit/parsers/repairsteps/icalendar/icalendarAddMissingUIDRepairStep.test.js
+++ b/tests/unit/parsers/repairsteps/icalendar/icalendarAddMissingUIDRepairStep.test.js
@@ -23,6 +23,8 @@ import ICalendarAddMissingUIDRepairStep
 	from '../../../../../src/parsers/repairsteps/icalendar/icalendarAddMissingUIDRepairStep.js';
 import AbstractRepairStep from '../../../../../src/parsers/repairsteps/abstractRepairStep.js';
 
+jest.mock('../../../../../src/helpers/cryptoHelper.js')
+
 it('The repair step should inherit from AbstractRepairStep', () => {
 	expect((new ICalendarAddMissingUIDRepairStep() instanceof AbstractRepairStep)).toEqual(true)
 })


### PR DESCRIPTION
#### Description 

This commit removes the `uuid` npm-dependency in favor of the browser-native [`randomUUID`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID)-function.

#### Notes on compatibility

The [`randomUUID`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID)-function is supported by all Nextcloud-supported browsers:
* https://docs.nextcloud.com/server/latest/user_manual/sv/webinterface.html#web-browser-requirements
* https://browserslist.dev/?q=PjAuMjUlLCBub3Qgb3BfbWluaSBhbGwsIG5vdCBkZWFkLCBGaXJlZm94IEVTUg%3D%3D
* https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#browser_compatibility

#### Pros

* Less dependencies, less supply-chain issues, less renovatebot noise
* Dependent packages have to install one less dependency
* When used by the Nextcloud Tasks app, the Tasks app JS bundle will be about 0.32 kB (gzip) smaller

#### Cons

* No more compatibility fallback for old browsers

#### Unsolicited meme

<details>
<img src="https://github.com/user-attachments/assets/822cad02-20fc-4ea1-aa62-d257a7996068" />
<details>