### PR TITLE
Fix todo timeframe check

### DIFF
--- a/src/components/root/toDoComponent.js
+++ b/src/components/root/toDoComponent.js
@@ -150,10 +150,10 @@ export default class ToDoComponent extends AbstractRecurringComponent {
 		}
 
 		if (!this.hasProperty('dtstart') && this.hasProperty('due')) {
-			return start.compare(this.getFirstProperty('due').value) <= 0
+			return start.compare(this.endDate) <= 0
 		}
 
-		return start.compare(this.getFirstProperty('due').value) <= 0 && end.compare(this.startDate) >= 0
+		return start.compare(this.endDate) <= 0 && end.compare(this.startDate) >= 0
 	}
 
 	/**


### PR DESCRIPTION
The isInTimeFrame check of the Todo Component was missing the case that there is a dtstart but no due date. Furthermore, since endDate is not updated when the due property is updated it makes more sense to use the due property value.

This is relevant for the task scheduling feature in the calendar app: 
Ref (feature): [#7110](https://github.com/nextcloud/calendar/pull/7110)